### PR TITLE
Bumped version of Wildfly to 8.0.0.Beta1

### DIFF
--- a/switchyard-wildfly/Dockerfile
+++ b/switchyard-wildfly/Dockerfile
@@ -1,8 +1,8 @@
-FROM jboss/wildfly:latest
+FROM jboss/wildfly:8.1.0.Final
 MAINTAINER Jorge Morales <jmorales@redhat.com>
 
-ENV JBOSS_SY_VERSION 2.0.0.Alpha3
-ENV JBOSS_SY_VERSION_MAIN 2.0.Alpha3
+ENV JBOSS_SY_VERSION 2.0.0.Beta1
+ENV JBOSS_SY_VERSION_MAIN 2.0.Beta1
 
 #
 # Install switchyard


### PR DESCRIPTION
Bumped version of Wildfly to 8.0.0.Beta1 and based on WildFly 8.1.0.Final as it does not work on Wildfly 8.2.0.Final
